### PR TITLE
Better handle non-interactive use

### DIFF
--- a/bin/retrace.dart
+++ b/bin/retrace.dart
@@ -11,14 +11,15 @@ main(List<String> args) {
   }
 
   try {
-    var retracer = new Retracer(args[0]);
-    print("Paste your minified trace here:");
+    var retracer = new Retracer(args[0], useColors: stdout.hasTerminal);
+    if(stdioType(stdin) == StdioType.TERMINAL)
+      print("Paste your minified trace here:");
     var lines = [];
     while(true) {
       var line = stdin.readLineSync();
-      if (line.isEmpty) {
+      if (line == null || line.isEmpty) {
         String trace = retracer.run(lines);
-        print("\n$trace\n");
+        print("$trace");
         break;
       } else {
         lines.add(line);

--- a/lib/retrace.dart
+++ b/lib/retrace.dart
@@ -7,8 +7,9 @@ import 'package:path/path.dart' as p;
 class Retracer {
   Mapping _mapping;
   List<String> _output = [];
+  bool useColors;
 
-  Retracer(String filename) {
+  Retracer(String filename, {this.useColors}) {
     try {
       var json = new File(filename).readAsStringSync();
       _mapping = parse(json);
@@ -30,7 +31,7 @@ class Retracer {
         // therefore, make a new search with the preceding line
         span = _mapping.spanFor(lineCol.line - 2, 99999);
         if (span == null) {
-          _output.add("${Colors.YELLOW}$text${Colors.NONE}");
+          _output.add(yellow(text));
           continue;
         }
       }
@@ -46,7 +47,7 @@ class Retracer {
         source = "";
       }
       source = "$source:${span.start.line + 1}".padRight(40);
-      _output.add('    at $source ${Colors.RED}${span.text}${Colors.NONE} (col ${span.start.column + 1})');
+      _output.add('    at $source ${red(text)} (col ${span.start.column + 1})');
     };
     return _output.join("\n");
   }
@@ -68,6 +69,9 @@ class Retracer {
     var column = int.parse(match[3]);
     return new LineCol(line, column);
   }
+
+  String red(String text) => useColors ? "${Colors.RED}${text}${Colors.NONE}" : text;
+  String yellow(String text) => useColors ? "${Colors.YELLOW}${text}${Colors.NONE}" : text;
 }
 
 class LineCol {


### PR DESCRIPTION
This commit improves interactive use in two ways:
1. The "Paste your minified trace here:" message is only printed if stdin is a terminal.
2. The escape codes to colorize output are only printed if stdout is a terminal.
