### PR TITLE
Add --format option

### DIFF
--- a/bin/retrace.dart
+++ b/bin/retrace.dart
@@ -3,23 +3,46 @@
 
 import 'dart:io';
 import 'package:retrace/retrace.dart';
+import 'package:args/args.dart';
 
 main(List<String> args) {
-  if (args.length != 1) {
-    print("Usage: retrace <map>");
+  var parser = new ArgParser(allowTrailingOptions: true);
+  parser.addOption('format',
+      help: "How output should be displayed.",
+      allowed: ['text', 'json'],
+      defaultsTo: 'text');
+
+  ArgResults argResults;
+  try{
+    argResults = parser.parse(args);
+  } on FormatException catch (ex){
+    print(ex.message);
     exit(1);
   }
+  if (argResults.rest.length != 1) {
+    print("Usage: retrace <map>");
+    print("");
+    print(parser.usage);
+    exit(1);
+  }
+  String format = argResults['format'];
 
   try {
-    var retracer = new Retracer(args[0], useColors: stdout.hasTerminal);
-    if(stdioType(stdin) == StdioType.TERMINAL)
+    var retracer = new Retracer(argResults.rest.single);
+    if(stdioType(stdin) == StdioType.TERMINAL && format == 'text')
       print("Paste your minified trace here:");
     var lines = [];
     while(true) {
       var line = stdin.readLineSync();
       if (line == null || line.isEmpty) {
-        String trace = retracer.run(lines);
-        print("$trace");
+        var trace = retracer.run(lines);
+        if(format == 'text'){
+          var fmtr = new TextFormatter(useColors: stdout.hasTerminal);
+          print(fmtr.format(trace));
+        } else {
+          var fmtr = new JsonFormatter();
+          print(fmtr.format(trace));
+        }
         break;
       } else {
         lines.add(line);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,6 +4,7 @@ description: Regenerates minified stacktraces.
 author: Björn Melinder <bjorn.melinder@gmail.com>
 homepage: https://github.com/bjornm/retrace
 dependencies:
+  args: ">=0.13.0 <0.14.0"
   source_maps: ">=0.10.0+1 <1.0.0"
 dev_dependencies:
   unittest: any


### PR DESCRIPTION
I'm writing a logger which records the stacktraces we experience in production and stores them in our log system. I have to reformat them to store them properly, and it would be easier to do if the program output was in a machine readable format.

To do this, I added a `--format` option which accepts either a 'text' or 'json' argument. Text format, the default, prints the same as before. The json format pretty-prints like so:

```
[
  {
    "source": "compiler/js_lib/js_helper.dart",
    "raw": "at dart.b (http://localhost:5700/static/app.js:1340:3)",
    "line": 1458,
    "column": 1
  },
  {
    "source": "my_app/popup.dart",
    "raw": "at Lf.dart.Lf.$0 (http://localhost:5700/static/app.js:7524:23)",
    "line": 73,
    "column": 56
  }
]
```

I did a little bit of refactoring to the retracer with this. `Retracer.run` now returns `List<RetracedLine>` which is the intermediate format given to the formatter. The new `TextFormatter` takes care of the coloring and the formatting, and the similar `JsonFormatter` takes care of formatting for json output.

I added the `args` package to the pubspec for parsing the command line arguments. It looks like it was already included in the lock file, but I added it here explicitly incase the `source_maps` dependencies change.
