### PR TITLE
Minimal changes for dart 1+2 support

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,4 @@
+analyzer:
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: true

--- a/bin/retrace.dart
+++ b/bin/retrace.dart
@@ -25,13 +25,13 @@ main(List<String> args) {
     print(parser.usage);
     exit(1);
   }
-  String format = argResults['format'];
+  String format = argResults['format'] as String;
 
   try {
     var retracer = new Retracer(argResults.rest.single);
     if(stdioType(stdin) == StdioType.TERMINAL && format == 'text')
       print("Paste your minified trace here:");
-    var lines = [];
+    var lines = <String>[];
     while(true) {
       var line = stdin.readLineSync();
       if (line == null || line.isEmpty) {

--- a/lib/retrace.dart
+++ b/lib/retrace.dart
@@ -67,8 +67,8 @@ class Retracer {
       return null;
     }
 
-    var line = int.parse(match[2]);
-    var column = int.parse(match[3]);
+    var line = int.parse(match[2] as String);
+    var column = int.parse(match[3] as String);
     return new LineCol(line, column);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,10 +4,9 @@ description: Regenerates minified stacktraces.
 author: Björn Melinder <bjorn.melinder@gmail.com>
 homepage: https://github.com/bjornm/retrace
 dependencies:
-  args: ">=0.13.0 <0.14.0"
+  args: "^1.5.0"
   source_maps: ">=0.10.0+1 <1.0.0"
 dev_dependencies:
   test: any
-  guinness2: "^0.0.3"
 executables:
   retrace:

--- a/test/retrace_test.dart
+++ b/test/retrace_test.dart
@@ -1,26 +1,26 @@
 library retrace_test;
 
 import 'package:retrace/retrace.dart';
-import 'package:guinness2/guinness2.dart';
+import 'package:test/test.dart';
 
 void main() {
-  describe('LineCol', () {
-    it('should have a working equals operator', () {
-      expect(new LineCol(1, 2)).toEqual(new LineCol(1, 2));
+  group('LineCol', () {
+    test('should have a working equals operator', () {
+      expect(new LineCol(1, 2), new LineCol(1, 2));
     });
   });
 
-  describe('parseLine', () {
-    it('should not parse empty line', () => expect(Retracer.parseLine(""), null));
-    it('should not parse mumbo characters', () => expect(Retracer.parseLine(" asdf asdf "), null));
-    it('should parse chrome format', () {
-      expect(Retracer.parseLine("    at WK.X4 (http://www.example.com/example.dart.js:17106:31)")).toEqual(new LineCol(17106, 31));
+  group('parseLine', () {
+    test('should not parse empty line', () => expect(Retracer.parseLine(""), null));
+    test('should not parse mumbo characters', () => expect(Retracer.parseLine(" asdf asdf "), null));
+    test('should parse chrome format', () {
+      expect(Retracer.parseLine("    at WK.X4 (http://www.example.com/example.dart.js:17106:31)"), new LineCol(17106, 31));
     });
-    it('should parse safari format', () {
-      expect(Retracer.parseLine("R5@http://www.example.com/example.dart.js:17106:31")).toEqual(new LineCol(17106, 31));
+    test('should parse safari format', () {
+      expect(Retracer.parseLine("R5@http://www.example.com/example.dart.js:17106:31"), new LineCol(17106, 31));
     });
-    it('should parse stack_trace package format', () {
-      expect(Retracer.parseLine("game.html.polymer.bootstrap.dart.js 21400:6   Pc.dart.Pc.bh")).toEqual(new LineCol(21400, 6));
+    test('should parse stack_trace package format', () {
+      expect(Retracer.parseLine("game.html.polymer.bootstrap.dart.js 21400:6   Pc.dart.Pc.bh"), new LineCol(21400, 6));
     });
   });
 }


### PR DESCRIPTION
Still works on dart 1.24.3 at least.
Removed dependency on guinness2, since that doesn't have a dart 2 release.